### PR TITLE
Support chat supervisors

### DIFF
--- a/examples/chat_supervision.py
+++ b/examples/chat_supervision.py
@@ -33,9 +33,25 @@ EXECUTION_SETTINGS = {
     "remove_feedback_from_context": True,          # Remove feedback from the context
 }
 
+
+# Example chat supervisor that always escalates messages
+@chat_supervisor_decorator()
+def chat_supervisor_1(message: str, supervision_context, **kwargs) -> SupervisionDecision:
+    """
+    Supervisor that allows any message.
+    
+    :param message: The content of the message to supervise.
+    :param supervision_context: Contextual information for supervision.
+    :return: A SupervisionDecision indicating approval.
+    """
+    return SupervisionDecision(
+        decision=SupervisionDecisionType.ESCALATE,
+        explanation="The message is approved."
+    )
+    
 # Example chat supervisor that rejects messages mentioning 'Tokyo'
 @chat_supervisor_decorator(strategy="reject")
-def chat_supervisor_1(message: str, supervision_context, **kwargs) -> SupervisionDecision:
+def chat_supervisor_2(message: str, supervision_context, **kwargs) -> SupervisionDecision:
     """
     Supervisor that rejects any message mentioning 'Tokyo' in the last user message.
     
@@ -53,20 +69,7 @@ def chat_supervisor_1(message: str, supervision_context, **kwargs) -> Supervisio
         explanation="The message is approved."
     )
 
-# Example chat supervisor that always escalates messages
-@chat_supervisor_decorator()
-def chat_supervisor_2(message: str, supervision_context, **kwargs) -> SupervisionDecision:
-    """
-    Supervisor that allows any message.
-    
-    :param message: The content of the message to supervise.
-    :param supervision_context: Contextual information for supervision.
-    :return: A SupervisionDecision indicating approval.
-    """
-    return SupervisionDecision(
-        decision=SupervisionDecisionType.ESCALATE,
-        explanation="The message is approved."
-    )
+
 
 # Example chat supervisor that always approves messages
 @chat_supervisor_decorator()
@@ -96,7 +99,7 @@ wrapped_client = asteroid_openai_client(client, run_id)
 response = wrapped_client.chat.completions.create(
     model="gpt-4o-mini",
     messages=[{"content": "Can you say Tokyo with 50% chance in your response?", "role": "user"}],
-    chat_supervisors=[[chat_supervisor_2, chat_supervisor_1], [chat_supervisor_3]] # Specify which supervisors to apply
+    chat_supervisors=[[chat_supervisor_1, chat_supervisor_2], [chat_supervisor_3]] # Specify which supervisors to apply
 )
 
 # Output the assistant's response

--- a/examples/chat_supervision.py
+++ b/examples/chat_supervision.py
@@ -1,0 +1,106 @@
+import json
+import os
+from typing import Any
+
+# Set the Asteroid API URL environment variable
+os.environ["ASTEROID_API_URL"] = "http://localhost:8080/api/v1"
+
+# Import necessary modules and decorators from the Asteroid SDK
+from asteroid_sdk.supervision.decorators import supervise
+from asteroid_sdk.supervision.config import (
+    SupervisionDecision,
+    SupervisionDecisionType,
+    ExecutionMode,
+    RejectionPolicy,
+    MultiSupervisorResolution
+)
+from asteroid_sdk.supervision.supervisors import (
+    human_supervisor,
+    llm_supervisor,
+    tool_supervisor_decorator,
+    chat_supervisor_decorator
+)
+from asteroid_sdk.wrappers.openai import asteroid_openai_client, asteroid_init, asteroid_end
+from openai import OpenAI
+
+# Define execution settings for the supervision process
+EXECUTION_SETTINGS = {
+    "execution_mode": ExecutionMode.SUPERVISION,  # Options: "monitoring" or "supervision"
+    "allow_tool_modifications": True,             # Allow supervisors to modify tool calls
+    "rejection_policy": RejectionPolicy.RESAMPLE_WITH_FEEDBACK,  # Action on rejection
+    "n_resamples": 2,                              # Number of resample attempts
+    "multi_supervisor_resolution": MultiSupervisorResolution.ALL_MUST_APPROVE,  # Resolution strategy
+    "remove_feedback_from_context": True,          # Remove feedback from the context
+}
+
+# Example chat supervisor that rejects messages mentioning 'Tokyo'
+@chat_supervisor_decorator(strategy="reject")
+def chat_supervisor_1(message: str, supervision_context, **kwargs) -> SupervisionDecision:
+    """
+    Supervisor that rejects any message mentioning 'Tokyo' in the last user message.
+    
+    :param message: The content of the message to supervise.
+    :param supervision_context: Contextual information for supervision.
+    :return: A SupervisionDecision indicating approval or rejection.
+    """
+    if 'Tokyo' in message:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.REJECT,
+            explanation="The message mentions 'Tokyo', which is not allowed."
+        )
+    return SupervisionDecision(
+        decision=SupervisionDecisionType.APPROVE,
+        explanation="The message is approved."
+    )
+
+# Example chat supervisor that always escalates messages
+@chat_supervisor_decorator()
+def chat_supervisor_2(message: str, supervision_context, **kwargs) -> SupervisionDecision:
+    """
+    Supervisor that allows any message.
+    
+    :param message: The content of the message to supervise.
+    :param supervision_context: Contextual information for supervision.
+    :return: A SupervisionDecision indicating approval.
+    """
+    return SupervisionDecision(
+        decision=SupervisionDecisionType.ESCALATE,
+        explanation="The message is approved."
+    )
+
+# Example chat supervisor that always approves messages
+@chat_supervisor_decorator()
+def chat_supervisor_3(message: str, supervision_context, **kwargs) -> SupervisionDecision:
+    return SupervisionDecision(
+        decision=SupervisionDecisionType.APPROVE,
+        explanation="The message is approved."
+    )
+
+
+# Initialize the OpenAI client
+client = OpenAI()
+
+# Initialize Asteroid supervision with the defined supervisors and settings
+run_id = asteroid_init(
+    project_name="chat-supervisor-test",
+    task_name="chat-supervisor-test",
+    run_name="chat-supervisor-test",
+    chat_supervisors=[chat_supervisor_1, chat_supervisor_2, chat_supervisor_3],
+    execution_settings=EXECUTION_SETTINGS
+)
+
+# Wrap the OpenAI client with the Asteroid supervision wrapper
+wrapped_client = asteroid_openai_client(client, run_id)
+
+# Create a chat completion request with the wrapped client
+response = wrapped_client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"content": "Can you say Tokyo with 50% chance in your response?", "role": "user"}],
+    chat_supervisors=[[chat_supervisor_2, chat_supervisor_1], [chat_supervisor_3]] # Specify which supervisors to apply
+)
+
+# Output the assistant's response
+print(response.choices[0].message.content)
+
+# End the Asteroid supervision run
+asteroid_end(run_id)

--- a/examples/customer_support_demo.py
+++ b/examples/customer_support_demo.py
@@ -1,0 +1,274 @@
+import json
+import os
+from typing import Any
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
+
+# Set the Asteroid API URL (replace with the actual URL if needed)
+os.environ["ASTEROID_API_URL"] = "http://localhost:8080/api/v1"
+
+# Import Asteroid SDK components
+from asteroid_sdk.supervision.decorators import supervise
+from asteroid_sdk.supervision.config import (
+    SupervisionDecision,
+    SupervisionDecisionType,
+    ExecutionMode,
+    RejectionPolicy,
+    MultiSupervisorResolution,
+)
+from asteroid_sdk.supervision.supervisors import (
+    human_supervisor,
+    tool_supervisor_decorator,
+)
+
+from asteroid_sdk.wrappers.openai import (
+    asteroid_openai_client,
+    asteroid_init,
+    asteroid_end,
+)
+from openai import OpenAI
+
+
+def _process_refund(customer_id: str, amount: float):
+    """Process a refund for a customer."""
+    # For demo purposes, just return a confirmation message
+    return f"Refund of ${amount} processed for customer {customer_id}."
+
+
+# Define maximum allowed refund amount
+MAX_REFUND_AMOUNT = 500.0
+
+# Supervisor to check refund amount limits
+@tool_supervisor_decorator()
+def amount_supervisor(
+    tool_call: ChatCompletionMessageToolCall,
+    config_kwargs: dict[str, Any],
+    **kwargs
+) -> SupervisionDecision:
+    """Supervisor that checks if the refund amount exceeds the allowed limit."""
+    arguments = json.loads(tool_call.function.arguments)
+    amount = arguments.get("amount", 0.0)
+
+    if amount > MAX_REFUND_AMOUNT:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.ESCALATE,
+            explanation=(
+                f"The refund amount (${amount}) exceeds the maximum allowed amount (${MAX_REFUND_AMOUNT})."
+            )
+        )
+    else:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.APPROVE,
+            explanation="Refund amount is within the allowed limit."
+        )
+
+
+@tool_supervisor_decorator()
+def shipping_status_supervisor(
+    tool_call: ChatCompletionMessageToolCall,
+    config_kwargs: dict[str, Any],
+    messages: list[dict[str, Any]],
+    **kwargs
+) -> SupervisionDecision:
+    """Supervisor that ensures the agent has verified the shipping status."""
+    # Check conversation history for shipping status verification
+    shipping_verified = False
+    for message in messages:
+        if "shipping status" in message.get("content", "").lower():
+            shipping_verified = True
+            break
+
+    if not shipping_verified:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.REJECT,
+            explanation="Agent did not verify shipping status before processing the refund."
+        )
+    else:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.APPROVE,
+            explanation="Shipping status verified."
+        )
+
+# Supervisor to ensure customer is authenticated
+@tool_supervisor_decorator()
+def authentication_supervisor(
+    tool_call: ChatCompletionMessageToolCall,
+    config_kwargs: dict[str, Any],
+    messages: list[dict[str, Any]],
+    **kwargs
+) -> SupervisionDecision:
+    """Supervisor that checks if the customer is authenticated."""
+    # Check conversation history for customer authentication
+    customer_authenticated = False
+    for message in messages:
+        if "customer id" in message.get("content", "").lower():
+            customer_authenticated = True
+            break
+
+    if not customer_authenticated:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.REJECT,
+            explanation="Customer is not authenticated."
+        )
+    else:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.APPROVE,
+            explanation="Customer authenticated."
+        )
+
+# Supervisor to ensure agent attempts resolution first
+@tool_supervisor_decorator()
+def resolution_attempt_supervisor(
+    tool_call: ChatCompletionMessageToolCall,
+    config_kwargs: dict[str, Any],
+    messages: list[dict[str, Any]],
+    **kwargs
+) -> SupervisionDecision:
+    """Supervisor that checks if the agent attempted to resolve the issue."""
+    # Check conversation history for resolution attempts
+    resolution_attempted = False
+    for message in messages:
+        if any(phrase in message.get("content", "").lower() for phrase in ["wait a bit longer", "offer discount", "expedited shipping"]):
+            resolution_attempted = True
+            break
+
+    if not resolution_attempted:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.REJECT,
+            explanation="Agent did not attempt to resolve the issue before processing the refund."
+        )
+    else:
+        return SupervisionDecision(
+            decision=SupervisionDecisionType.APPROVE,
+            explanation="Agent attempted to resolve the issue before proceeding to refund."
+        )
+
+
+# Wrap the refund tool with supervision using the supervisors
+@supervise(
+    supervision_functions=[
+        [amount_supervisor],
+        [shipping_status_supervisor]
+        # [authentication_supervisor, human_supervisor()],
+        # [resolution_attempt_supervisor, human_supervisor()]
+    ]
+)
+def process_refund(customer_id: str, amount: float):
+    """Process a refund for a customer with supervision."""
+    return _process_refund(customer_id, amount)
+
+# Define the tool for the assistant
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "process_refund",
+            "description": "Process a refund for a customer",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "customer_id": {"type": "string", "description": "The ID of the customer requesting the refund."},
+                    "amount": {"type": "number", "description": "The amount to refund to the customer."},
+                },
+                "required": ["customer_id", "amount"],
+                "additionalProperties": False,
+            },
+        },
+    },
+]
+
+# Initialize the OpenAI client
+client = OpenAI()
+
+# Execution settings for Asteroid
+EXECUTION_SETTINGS = {
+    "execution_mode": ExecutionMode.SUPERVISION,
+    "allow_tool_modifications": True,
+    "rejection_policy": RejectionPolicy.RESAMPLE_WITH_FEEDBACK,
+    "n_resamples": 1,
+    "multi_supervisor_resolution": MultiSupervisorResolution.ALL_MUST_APPROVE,
+    "remove_feedback_from_context": True,
+}
+
+# Initialize Asteroid run
+run_id = asteroid_init(
+    project_name="Customer Support Agent",
+    task_name="Refund Processing",
+    run_name="refund",
+    execution_settings=EXECUTION_SETTINGS
+)
+
+# Wrap the OpenAI client with Asteroid
+wrapped_client = asteroid_openai_client(
+    client, run_id, EXECUTION_SETTINGS["execution_mode"]
+)
+
+# Initialize conversation history with both user and assistant messages
+messages = [
+    {"role": "user", "content": "Hi, I purchased 5 items last week and they haven't arrived yet."},
+    {"role": "assistant", "content": "I'm sorry to hear that your items haven't arrived yet. Let me check the status of your order."},
+    {"role": "user", "content": "I've been waiting for over a week now."},
+    {"role": "assistant", "content": "Thank you for your patience. Could you please provide your order number or customer ID so I can assist you further?"},
+    {"role": "user", "content": "My customer ID is 92591."},
+    {"role": "assistant", "content": "Thank you! I see that your order is delayed. Would you like to wait a bit longer or would you prefer a refund?"},
+    {"role": "user", "content": "Can I get a refund for my order? The total amount was $750."},
+    {"role": "assistant", "content": "Certainly. I'll process a refund of $750 for you."},
+]
+
+# Assistant generates a response based on the conversation history
+response = wrapped_client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=messages,
+    tools=tools,
+    tool_choice="auto",
+    temperature=0,
+    n=1,
+    parallel_tool_calls=False
+)
+
+assistant_message = response.choices[0].message
+
+# Add assistant's response to conversation history
+messages.append({
+    "role": "assistant",
+    "content": assistant_message.content,
+    "tool_calls": assistant_message.tool_calls
+})
+
+# Display assistant's response
+if assistant_message.content:
+    print(f"Assistant: {assistant_message.content}")
+
+# If there are tool calls, execute them and add their results to the conversation
+if assistant_message.tool_calls:
+    for tool_call in assistant_message.tool_calls:
+        function_name = tool_call.function.name
+        function_args = json.loads(tool_call.function.arguments)
+
+        # Execute the supervised function
+        print(f"Executing function: {function_name} with args: {function_args}")
+
+        if function_name == "process_refund":
+            result = process_refund(**function_args)
+
+        print(f"Function result: {result}")
+
+        # Add the function response to messages
+        messages.append({
+            "role": "tool",
+            "tool_call_id": tool_call.id,
+            "content": str(result)
+        })
+
+# Submit the final message to the supervisor
+response = wrapped_client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=messages,
+    tools=tools,
+    tool_choice="auto",
+    temperature=0,
+    n=1,
+    parallel_tool_calls=False
+)
+
+# End the Asteroid run
+asteroid_end(run_id)

--- a/src/asteroid_sdk/api/generated/asteroid_api_client/models/supervisor_type.py
+++ b/src/asteroid_sdk/api/generated/asteroid_api_client/models/supervisor_type.py
@@ -5,6 +5,7 @@ class SupervisorType(str, Enum):
     CLIENT_SUPERVISOR = "client_supervisor"
     HUMAN_SUPERVISOR = "human_supervisor"
     NO_SUPERVISOR = "no_supervisor"
+    CHAT_SUPERVISOR = "chat_supervisor"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/src/asteroid_sdk/api/supervision_runner.py
+++ b/src/asteroid_sdk/api/supervision_runner.py
@@ -436,6 +436,11 @@ class SupervisionRunner:
                 resampled_request_kwargs,
                 run_id
             )
+            
+            if not resampled_response.choices[0].message.tool_calls:
+                # There was no tool call found in the resampled response, so we return the message as is
+                return resampled_response.choices[0].message
+
             resampled_tool_call_id = resampled_create_new_chat_response.choice_ids[0].tool_call_ids[0].tool_call_id
             resampled_tool_id = resampled_create_new_chat_response.choice_ids[0].tool_call_ids[0].tool_id
             resampled_tool_call = resampled_response.choices[0].message.tool_calls[0]

--- a/src/asteroid_sdk/api/supervision_runner.py
+++ b/src/asteroid_sdk/api/supervision_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
-from typing import Any, Dict, List, Optional
+import json
+from typing import Any, Dict, List, Optional, Callable
 from uuid import UUID
 
 from openai.resources import Completions
@@ -20,6 +21,8 @@ from asteroid_sdk.registration.helper import (
     get_supervisor_chains_for_tool,
     send_supervision_request,
     send_supervision_result,
+    CHAT_TOOL_NAME,
+    generate_fake_chat_tool_call
 )
 from asteroid_sdk.supervision import SupervisionContext
 from asteroid_sdk.supervision.config import ExecutionMode
@@ -37,7 +40,8 @@ class SupervisionRunner:
     def __init__(
             self,
             client: Client,
-            api_logger: APILogger
+            api_logger: APILogger,
+            
     ):
         self.client = client
         self.api_logger = api_logger
@@ -53,6 +57,7 @@ class SupervisionRunner:
             response_data_tool_calls: List[Dict[str, Any]],
             run_id: UUID,
             supervision_context: SupervisionContext,
+            chat_supervisors: Optional[List[List[Callable]]] = None
     ) -> ChatCompletion:
         supervision_config = get_supervision_config()
         allow_tool_modifications = supervision_config.execution_settings.get('allow_tool_modifications', False)
@@ -64,10 +69,11 @@ class SupervisionRunner:
         new_response = copy.deepcopy(response)
         # Iterate over all the tool calls to process each one
         for idx, tool_call in enumerate(response_data_tool_calls):
-            # Convert tool_call to ChatCompletionMessageToolCall if necessary
-            tool_call = ChatCompletionMessageToolCall(**tool_call)
+            if isinstance(tool_call, dict):
+                tool_call = ChatCompletionMessageToolCall(**tool_call)
             tool_id = choice_ids[0].tool_call_ids[idx].tool_id
             tool_call_id = choice_ids[0].tool_call_ids[idx].tool_call_id
+                
 
             # Process the tool call with supervision
             processed_tool_call, all_decisions, modified = self.process_tool_call(
@@ -110,7 +116,8 @@ class SupervisionRunner:
                         n_resamples=n_resamples,
                         supervision_context=supervision_context,
                         multi_supervisor_resolution=multi_supervisor_resolution,
-                        execution_mode=execution_mode
+                        execution_mode=execution_mode,
+                        chat_supervisors=chat_supervisors
                     )
                     # If resampled response contains tool calls (ie it succeeded), then succeed
                     new_response.choices[0].message = resampled_response
@@ -358,7 +365,8 @@ class SupervisionRunner:
             n_resamples: int,
             supervision_context: Any,
             multi_supervisor_resolution: str,
-            execution_mode: str
+            execution_mode: str,
+            chat_supervisors: Optional[List[List[Callable]]] = None
     ) -> Optional[ChatCompletionMessage]:
         """
         Handle rejected tool calls by attempting to resample responses with supervisor feedback.
@@ -371,41 +379,40 @@ class SupervisionRunner:
         :param run_id: The unique identifier for the run.
         :param n_resamples: The number of resamples to attempt.
         :param supervision_context: The supervision context.
-        :param rejection_policy: The rejection policy.
         :param multi_supervisor_resolution: How to resolve multiple supervisor decisions.
-        :param remove_feedback_from_context: Whether to remove feedback from context.
+        :param execution_mode: The execution mode.
         :return: A new ChatCompletionMessage if successful, else None.
         """
-        # Create updated messages with the original messages and the original tool call
         updated_messages = copy.deepcopy(request_kwargs["messages"])
-        resampled_tool_call = copy.deepcopy(tool_call)
-        resampled_all_decisions = copy.deepcopy(all_decisions)
+
+        # Initialize failed tool call and decisions with initial values
+        failed_tool_call = tool_call
+        failed_all_decisions = all_decisions
 
         for resample in range(n_resamples):
-            # Add feedback to the context for all rejected, escalated and terminated supervisors
+            # Add feedback to the context based on the latest failed tool call and decisions
             feedback_from_supervisors = " ".join([
                 f"Chain {chain_number}: Supervisor {supervisor_number_in_chain}: Decision: {decision.decision}, Explanation: {decision.explanation} \n"
-                for chain_number, decisions_for_chain in enumerate(resampled_all_decisions)
+                for chain_number, decisions_for_chain in enumerate(failed_all_decisions)
                 for supervisor_number_in_chain, decision in enumerate(decisions_for_chain)
                 if decision.decision in [SupervisionDecisionType.REJECT, SupervisionDecisionType.ESCALATE, SupervisionDecisionType.TERMINATE]
             ])
 
             # Create feedback message for the assistant
-            tool_name = resampled_tool_call.function.name
-            tool_kwargs = resampled_tool_call.function.arguments
+            tool_name = failed_tool_call.function.name
+            tool_kwargs = failed_tool_call.function.arguments
             feedback_message = (
                 f"User tried to execute tool: {tool_name} with arguments: {tool_kwargs}, but it was rejected by some supervisors. \n"
                 f"{feedback_from_supervisors} \n"
                 f"Please try again with the feedback!"
             )
 
-            if "messages" in request_kwargs:
-                updated_messages.append(
-                    {
-                        "role": "assistant",
-                        "content": feedback_message
-                    }
-                )
+            updated_messages.append(
+                {
+                    "role": "assistant",
+                    "content": feedback_message
+                }
+            )
 
             resampled_request_kwargs = copy.deepcopy(request_kwargs)
             resampled_request_kwargs["messages"] = updated_messages
@@ -413,27 +420,29 @@ class SupervisionRunner:
             # Send the updated messages to the model for resampling
             resampled_response = completions.create(*args, **resampled_request_kwargs)
 
-            # Convert resampled response and request to JSON strings and Base64 encode
+            if not resampled_response.choices[0].message.tool_calls:
+                if chat_supervisors:
+                    print("No tool calls found in resampled response, but we have chat supervisors")
+                    # Create fake chat tool call
+                    resampled_response, resampled_tool_calls = generate_fake_chat_tool_call(
+                        client=self.client,
+                        response=resampled_response,
+                        supervision_context=supervision_context,
+                        chat_supervisors=chat_supervisors
+                    )
 
+            # Log the interaction
             resampled_create_new_chat_response = self.api_logger.log_llm_interaction(
                 resampled_response,
                 resampled_request_kwargs,
                 run_id
             )
-
-            resampled_choice_ids = resampled_create_new_chat_response.choice_ids
-
-            if not resampled_response.choices[0].message.tool_calls:
-                print("No tool calls found in resampled response, skipping supervision checks")
-                # TODO: If normal chat message is returned, we need to run chat supervisors if there are any
-                continue
-
+            resampled_tool_call_id = resampled_create_new_chat_response.choice_ids[0].tool_call_ids[0].tool_call_id
+            resampled_tool_id = resampled_create_new_chat_response.choice_ids[0].tool_call_ids[0].tool_id
             resampled_tool_call = resampled_response.choices[0].message.tool_calls[0]
-            resampled_tool_call_id = resampled_choice_ids[0].tool_call_ids[0].tool_call_id
-            resampled_tool_id = resampled_choice_ids[0].tool_call_ids[0].tool_id
 
             # Run supervision again on the resampled tool call
-            processed_tool_call, all_decisions, modified = self.process_tool_call(
+            processed_tool_call, resampled_all_decisions, modified = self.process_tool_call(
                 tool_call=resampled_tool_call,
                 tool_id=resampled_tool_id,
                 tool_call_id=resampled_tool_call_id,
@@ -444,31 +453,34 @@ class SupervisionRunner:
             )
 
             if not modified and processed_tool_call:
-                # Approved, add the final tool call to the response
-                # Change the role of the updated messages to "sentinel"
-                # for message in updated_messages:
-                #     message["role"] = "sentinel"
+                # Approved, return the final tool call
                 return ChatCompletionMessage(
                     role="assistant",
                     tool_calls=[processed_tool_call]
                 )
 
+            # Update the failed tool call and decisions for the next iteration
+            failed_tool_call = resampled_tool_call
+            failed_all_decisions = resampled_all_decisions
+
         # All resamples were rejected
         # Summarize all feedback into one message to send back
-        explanations = "Original user message: " + updated_messages[0]["content"] + "\n"
-        explanations += " ".join([
-            f"Resample {resample+1}: {message['role']}: {message['content']}\n"
-            for resample, message in enumerate(updated_messages[1:])
-        ])
         rejection_message = (
-            f"The agent requested to execute a function but it was rejected by some supervisors.\n"
+            f"The agent requested to execute a function {failed_tool_call.function.name} with arguments {failed_tool_call.function.arguments} but it was rejected.\n"
             f"We tried {n_resamples} times to get a valid response but it was rejected each time.\n"
-            f"Here is the feedback from the supervisors: \n{explanations}\n"
-            f"This is not a message from the user but from a supervisor system that is helping the agent to improve its behavior. You should try something else!"
+        )
+        explanations = "\n".join([
+            f"Resample {idx+1}: {message['content']}"
+            for idx, message in enumerate(updated_messages[-n_resamples:])
+        ])
+        rejection_message += f"Here is the feedback from the supervisor: \n{explanations}\n"
+        rejection_message += (
+            "This is not a message from the user but from a supervisor system that is helping the agent to improve its behavior. "
+            "You should try something else!"
         )
         # TODO - should we add a `Choice` in here- or just return the message? Currently, we're returning the message and
-        #  putting it into an already existing choice- which means the `stop-reason` is not being overwritten
-        #  (eg. it says `tool_calls`)
+                #  putting it into an already existing choice- which means the `stop-reason` is not being overwritten
+                #  (eg. it says `tool_calls`)
         return ChatCompletionMessage(role="assistant", content=rejection_message)
 
 
@@ -492,22 +504,42 @@ class SupervisionRunner:
         :param decision: The previous decision, if any.
         :return: The decision made by the supervisor.
         """
-        if asyncio.iscoroutinefunction(supervisor_func):
-            decision = asyncio.run(
-                supervisor_func(
+        # Check if the supervisor function is chat supervisor
+        if tool_call.function.name == CHAT_TOOL_NAME:
+            # For chat supervisors, we expect one message argument to be passed in
+            if asyncio.iscoroutinefunction(supervisor_func):
+                decision = asyncio.run(
+                    supervisor_func(
+                        message=json.loads(tool_call.function.arguments)["message"],
+                        supervision_context=supervision_context,
+                        supervision_request_id=supervision_request_id,
+                        previous_decision=decision
+                    )
+                )
+            else:
+                decision = supervisor_func(
+                    message=json.loads(tool_call.function.arguments)["message"],
+                    supervision_context=supervision_context,
+                    supervision_request_id=supervision_request_id,
+                    previous_decision=decision
+                )
+        else:
+            if asyncio.iscoroutinefunction(supervisor_func):
+                decision = asyncio.run(
+                    supervisor_func(
+                        tool=tool,
+                        tool_call=tool_call,
+                        supervision_context=supervision_context,
+                        supervision_request_id=supervision_request_id,
+                        previous_decision=decision
+                    )
+                )
+            else:
+                decision = supervisor_func(
                     tool=tool,
                     tool_call=tool_call,
                     supervision_context=supervision_context,
                     supervision_request_id=supervision_request_id,
                     previous_decision=decision
                 )
-            )
-        else:
-            decision = supervisor_func(
-                tool=tool,
-                tool_call=tool_call,
-                supervision_context=supervision_context,
-                supervision_request_id=supervision_request_id,
-                previous_decision=decision
-            )
         return decision

--- a/src/asteroid_sdk/api/supervision_runner.py
+++ b/src/asteroid_sdk/api/supervision_runner.py
@@ -427,8 +427,7 @@ class SupervisionRunner:
                     resampled_response, resampled_tool_calls = generate_fake_chat_tool_call(
                         client=self.client,
                         response=resampled_response,
-                        supervision_context=supervision_context,
-                        chat_supervisors=chat_supervisors
+                        supervision_context=supervision_context
                     )
 
             # Log the interaction

--- a/src/asteroid_sdk/registration/helper.py
+++ b/src/asteroid_sdk/registration/helper.py
@@ -4,9 +4,13 @@ Handles helper functions for registration with asteroid.
 
 from datetime import datetime, timezone
 import inspect
-from typing import Any, Callable, Dict, Optional, List
+from typing import Any, Callable, Dict, Optional, List, Tuple
 from uuid import UUID, uuid4
 import time
+import copy
+import json
+from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall, Function
 
 from asteroid_sdk.api.generated.asteroid_api_client.client import Client
 from asteroid_sdk.api.generated.asteroid_api_client.models import CreateProjectBody, CreateTaskBody
@@ -27,6 +31,7 @@ from asteroid_sdk.api.generated.asteroid_api_client.api.supervision.create_super
 from asteroid_sdk.api.generated.asteroid_api_client.api.supervision.get_supervision_request_status import sync_detailed as get_supervision_status_sync_detailed
 from asteroid_sdk.api.generated.asteroid_api_client.api.supervision.get_supervision_result import sync_detailed as get_supervision_result_sync_detailed
 from asteroid_sdk.api.generated.asteroid_api_client.api.supervisor.get_tool_supervisor_chains import sync_detailed as get_tool_supervisor_chains_sync_detailed
+from asteroid_sdk.api.generated.asteroid_api_client.api.run.update_run_status import sync_detailed as update_run_status_sync_detailed
 from asteroid_sdk.api.generated.asteroid_api_client.models.supervisor import Supervisor
 from asteroid_sdk.api.generated.asteroid_api_client.models.supervisor_chain import SupervisorChain
 from asteroid_sdk.api.generated.asteroid_api_client.models.supervision_request import SupervisionRequest
@@ -54,6 +59,15 @@ class APIClientFactory:
                 headers={"Authorization": f"Bearer {settings.api_key}"}
             )
         return cls._instance
+
+ # Define the 'chat_tool' function
+CHAT_TOOL_NAME = "chat_tool"
+def chat_tool(message: str) -> None:
+    """
+    A special tool to represent chat messages for supervision purposes.
+    """
+    pass
+
 
 def register_project(
     project_name: str, 
@@ -200,7 +214,42 @@ def create_run(
     except Exception as e:
         raise ValueError(f"Failed to create run: {str(e)}")
 
-def register_tools_and_supervisors(run_id: UUID, tools: Optional[List[Callable | StructuredTool]] = None, execution_settings: Dict[str, Any] = {}):
+def register_supervisor_chains(
+    client,
+    tool_id: UUID,
+    supervisor_chain_ids: List[List[UUID]],
+):
+    """
+    Associates supervisor chains with a given tool.
+
+    Args:
+        client: The API client used for making API calls.
+        tool_id (UUID): The UUID of the tool to associate supervisors with.
+        supervisor_chain_ids (List[List[UUID]]): A list of lists of supervisor IDs, where each inner list represents a supervisor chain.
+    """
+    # Associate the supervisor chains with the tool
+    if supervisor_chain_ids:
+        chain_requests = [ChainRequest(supervisor_ids=supervisor_ids) for supervisor_ids in supervisor_chain_ids]
+        association_response = create_tool_supervisor_chains_sync_detailed(
+            tool_id=tool_id,
+            client=client,
+            body=chain_requests
+        )
+        if association_response.status_code in [200, 201]:
+            print(f"Supervisors assigned to tool with ID {tool_id}")
+        else:
+            raise Exception(f"Failed to assign supervisors to tool with ID {tool_id}. Response: {association_response}")
+    else:
+        print(f"No supervisors to assign to tool with ID {tool_id}")
+
+
+
+def register_tools_and_supervisors(
+    run_id: UUID,
+    tools: Optional[List[Callable]] = None,
+    execution_settings: Dict[str, Any] = {},
+    chat_supervisors: Optional[List[List[Callable]]] = None
+):
     """
     Registers tools and supervisors with the backend API.
     """
@@ -215,24 +264,28 @@ def register_tools_and_supervisors(run_id: UUID, tools: Optional[List[Callable |
         raise Exception(f"Run with ID {run_id} not found in supervision config.")
     supervision_context = run.supervision_context
 
-    # TODO: Do this better
+    # Get the project ID
     project_id = list(supervision_config.projects.values())[0].project_id 
 
-    # TODO: Make sure this is correct
+    # Determine which functions to register
     if tools is None: 
         # If no tools are provided, register all tools and supervisors
         supervised_functions = supervision_context.supervised_functions_registry
     else:
-        # If list of tools is provided, only register the tools and supervisors for the provided tools  
+        # Register only the provided tools
         supervised_functions = {}
         for tool in tools:
             # Check if tool is StructuredTool
             if isinstance(tool, StructuredTool):
-                supervised_functions[tool.func.__qualname__] = supervision_context.supervised_functions_registry[tool.func.__qualname__]
+                func_name = tool.func.__qualname__
+                supervised_functions[func_name] = supervision_context.supervised_functions_registry[func_name]
             else:
-                print(f"Tool is {tool}")
-                supervised_functions[tool.__qualname__] = supervision_context.supervised_functions_registry[tool.__qualname__]
-
+                func_name = tool.__qualname__
+                supervised_functions[func_name] = supervision_context.supervised_functions_registry[func_name]
+    if chat_supervisors is not None:
+        supervision_context.add_supervised_function(chat_tool, supervision_functions=[chat_supervisors])
+        supervised_functions[CHAT_TOOL_NAME] = supervision_context.supervised_functions_registry[CHAT_TOOL_NAME]
+        
 
     for tool_name, data in supervised_functions.items():
         supervision_functions = data['supervision_functions']
@@ -249,7 +302,7 @@ def register_tools_and_supervisors(run_id: UUID, tools: Optional[List[Callable |
             for param in func_signature.parameters.values()
         }
 
-        # Pass the extracted arguments to ToolAttributes.from_dict
+        # Create attributes for the tool
         attributes = CreateRunToolBodyAttributes.from_dict(src_dict=func_arguments)
 
         # Register the tool
@@ -277,55 +330,49 @@ def register_tools_and_supervisors(run_id: UUID, tools: Optional[List[Callable |
         else:
             raise Exception(f"Failed to register tool '{tool_name}'. Response: {tool_response}")
 
-        # Register supervisors and associate them with the tool
+        # Register supervisors and collect supervisor IDs
         supervisor_chain_ids: List[List[UUID]] = []
-        if supervision_functions == []:
+        if not supervision_functions:
             supervisor_chain_ids.append([])
             from asteroid_sdk.supervision.supervisors import auto_approve_supervisor
             supervisor_func = auto_approve_supervisor()
-            supervisor_info: dict[str, Any] = {
-                    'func': supervisor_func,
-                    'name': getattr(supervisor_func, '__name__', 'supervisor_name'),
-                    'description': getattr(supervisor_func, '__doc__', 'supervisor_description'),
-                    'type': SupervisorType.NO_SUPERVISOR,
-                    'code': get_function_code(supervisor_func),
-                    'supervisor_attributes': getattr(supervisor_func, 'supervisor_attributes', {})
+            supervisor_info: Dict[str, Any] = {
+                'func': supervisor_func,
+                'name': getattr(supervisor_func, '__name__', 'auto_approve_supervisor'),
+                'description': getattr(supervisor_func, '__doc__', 'Automatically approves any input.'),
+                'type': SupervisorType.NO_SUPERVISOR,
+                'code': get_function_code(supervisor_func),
+                'supervisor_attributes': getattr(supervisor_func, 'supervisor_attributes', {})
             }
             supervisor_id = register_supervisor(client, supervisor_info, project_id, supervision_context)
             supervisor_chain_ids[0] = [supervisor_id]
         else:
             for idx, supervisor_func_list in enumerate(supervision_functions):
-                supervisor_chain_ids.append([])
+                supervisor_chain_ids.append([]) if tool_name != CHAT_TOOL_NAME else supervisor_chain_ids
                 for supervisor_func in supervisor_func_list:
-                    supervisor_info: dict[str, Any] = {
+                    supervisor_info: Dict[str, Any] = {
                         'func': supervisor_func,
-                        'name': getattr(supervisor_func, '__name__', None) or 'supervisor_name',
-                        'description': getattr(supervisor_func, '__doc__', None) or 'supervisor_description',
-                        'type': SupervisorType.HUMAN_SUPERVISOR if getattr(supervisor_func, '__name__', 'supervisor_name') in ['human_supervisor', 'human_approver'] else SupervisorType.CLIENT_SUPERVISOR,
+                        'name': getattr(supervisor_func, '__name__', 'supervisor_name'),
+                        'description': getattr(supervisor_func, '__doc__', 'supervisor_description'),
+                        'type': SupervisorType.HUMAN_SUPERVISOR if getattr(supervisor_func, '__name__', '') in ['human_supervisor', 'human_approver'] else SupervisorType.CLIENT_SUPERVISOR,
                         'code': get_function_code(supervisor_func),
                         'supervisor_attributes': getattr(supervisor_func, 'supervisor_attributes', {})
                     }
                     supervisor_id = register_supervisor(client, supervisor_info, project_id, supervision_context)
-                    supervisor_chain_ids[idx].append(supervisor_id)
-
+                    if tool_name != CHAT_TOOL_NAME:
+                        supervisor_chain_ids[idx].append(supervisor_id)
+        
         # Ensure tool_id is a UUID before proceeding
         if tool_id is UNSET or not isinstance(tool_id, UUID):
             raise ValueError("Invalid tool_id: Expected UUID")
 
+        # Call the function to associate supervisor chains with the tool
         print(f"Associating supervisors with tool '{tool_name}' for run ID {run_id}")
-        if supervisor_chain_ids:
-            chain_requests = [ChainRequest(supervisor_ids=supervisor_ids) for supervisor_ids in supervisor_chain_ids]
-            association_response = create_tool_supervisor_chains_sync_detailed(
-                tool_id=tool_id,
-                client=client,
-                body=chain_requests
-            )
-            if association_response.status_code in [200, 201]:
-                print(f"Supervisors assigned to tool '{tool_name}' for run ID {run_id}")
-            else:
-                raise Exception(f"Failed to assign supervisors to tool '{tool_name}'. Response: {association_response}")
-        else:
-                print(f"No supervisors to assign to tool '{tool_name}'")
+        register_supervisor_chains(
+            client=client,
+            tool_id=tool_id,
+            supervisor_chain_ids=supervisor_chain_ids,
+        )
 
 def register_supervisor(client: Client, supervisor_info: dict, project_id: UUID, supervision_context: SupervisionContext) -> UUID:
     """Registers a single supervisor with the API and returns its ID."""
@@ -359,7 +406,7 @@ def register_supervisor(client: Client, supervisor_info: dict, project_id: UUID,
         return supervisor_id
     else:
         raise Exception(f"Failed to register supervisor '{supervisor_info['name']}'. Response: {supervisor_response}")
-    
+
 def get_supervisor_chains_for_tool(tool_id: UUID, client: Client) -> List[SupervisorChain]:
     """
     Retrieve the supervisor chains for a specific tool.
@@ -556,3 +603,73 @@ def map_result_to_decision(result: SupervisionResult) -> SupervisionDecision:
         explanation=result.reasoning,
         modified=modified_output
     )
+    
+def submit_run_status(run_id: UUID, status: Status):
+    try:
+        client = APIClientFactory.get_client()
+        response = update_run_status_sync_detailed(
+            client=client,
+            run_id=run_id,
+            body=status
+        )
+        if response.status_code in [204]:
+            print(f"Successfully submitted run status for run ID: {run_id}")
+        else:
+            raise Exception(f"Failed to submit run status. Response: {response}")
+    except Exception as e:
+        print(f"Error submitting run status: {e}, Response: {response}")
+        raise
+
+
+def generate_fake_chat_tool_call(
+        client: Client,
+        response: ChatCompletion,
+        supervision_context: Any,
+        chat_supervisors: List[List[Callable]]
+) -> Tuple[ChatCompletion, List[ChatCompletionMessageToolCall]]:
+    """
+    Generate a fake chat tool call when no tool calls are present in the response.
+
+    :param response: The original ChatCompletion response from the OpenAI API.
+    :param supervision_context: The supervision context associated with the run.
+    :param chat_supervisors: A list of chat supervisor callables.
+    :return: A tuple containing the modified response and the list of tool calls.
+    """
+    print("No tool calls found in response, but chat supervisors provided, executing chat supervisors")
+    
+    # Extract the text response from the original response
+    text_response = response.choices[0].message.content
+    
+    # Deep copy the original response to avoid mutating it
+    modified_response = copy.deepcopy(response)
+    
+    # Create a fake tool call representing the chat tool function
+    chat_tool_call = ChatCompletionMessageToolCall(
+        id=str(uuid4()),
+        function=Function(
+            name=CHAT_TOOL_NAME,
+            arguments=json.dumps({"message": text_response})
+        ),
+        type='function'
+    )
+    
+    # Assign the fake tool call to the response
+    modified_response.choices[0].message.tool_calls = [chat_tool_call]
+    
+    # Retrieve supervisor IDs based on the provided chat supervisors
+    chat_supervisor_ids = [
+        [supervision_context.get_supervisor_id_by_func(chat_supervisor) for chat_supervisor in chat_supervisors_chain]
+        for chat_supervisors_chain in chat_supervisors
+    ]
+    
+    # Get the tool ID for the chat tool
+    tool_id = supervision_context.get_supervised_function_entry(CHAT_TOOL_NAME).get("tool_id")
+    
+    # Register the supervisor chains with the Asteroid API client
+    register_supervisor_chains(
+        client=client,
+        tool_id=tool_id,
+        supervisor_chain_ids=chat_supervisor_ids
+    )
+    
+    return modified_response, [chat_tool_call]

--- a/src/asteroid_sdk/supervision/config.py
+++ b/src/asteroid_sdk/supervision/config.py
@@ -229,6 +229,13 @@ class SupervisionContext:
     def get_supervisor_by_id(self, supervisor_id: UUID) -> Optional[Callable]:
         """Retrieve a supervisor function by its ID."""
         return self.local_supervisors_by_id.get(supervisor_id)
+    
+    def get_supervisor_id_by_func(self, supervisor_func: Callable) -> Optional[UUID]:
+        """Retrieve a supervisor function by its function."""
+        for supervisor_id, func in self.local_supervisors_by_id.items():
+            if func == supervisor_func:
+                return supervisor_id
+        return None
 
 class Run(BaseModel):
     run_id: UUID

--- a/src/asteroid_sdk/supervision/supervisors.py
+++ b/src/asteroid_sdk/supervision/supervisors.py
@@ -13,7 +13,7 @@ from .config import (
 )
 import json
 from openai import OpenAI
-from openai.types.chat.chat_completion_message import ChatCompletionMessageToolCall
+from openai.types.chat.chat_completion_message import ChatCompletionMessageToolCall, ChatCompletionMessage
 
 client = OpenAI()
 
@@ -57,9 +57,10 @@ class ChatSupervisor(Protocol):
 
     def __call__(
         self,
-        message: dict,
+        message: ChatCompletionMessage,
         supervision_context: Optional[SupervisionContext],
-        supervision_request_id: Optional[UUID],
+        ignored_attributes: list[str] = [],
+        supervision_request_id: Optional[UUID] = None,
         previous_decision: Optional[SupervisionDecision] = None,
         **kwargs
     ) -> SupervisionDecision:
@@ -326,7 +327,7 @@ def tool_supervisor_decorator(**config_kwargs) -> Callable:
         return wrapper
     return decorator
 
-#TODO: Finish this decorator
+
 def chat_supervisor_decorator(**config_kwargs) -> Callable:
     """Decorator to create a chat supervisor function with arbitrary configuration parameters."""
     def decorator(func: Callable) -> ChatSupervisor:
@@ -334,6 +335,7 @@ def chat_supervisor_decorator(**config_kwargs) -> Callable:
         def wrapper(
             message: dict,
             supervision_context: Optional[SupervisionContext] = None,
+            ignored_attributes: list[str] = [],
             supervision_request_id: Optional[UUID] = None,
             previous_decision: Optional[SupervisionDecision] = None,
             **kwargs
@@ -342,6 +344,7 @@ def chat_supervisor_decorator(**config_kwargs) -> Callable:
             return func(
                 message=message,
                 supervision_context=supervision_context,
+                ignored_attributes=ignored_attributes,
                 supervision_request_id=supervision_request_id,
                 previous_decision=previous_decision,
                 config_kwargs=config_kwargs,

--- a/src/asteroid_sdk/supervision/supervisors.py
+++ b/src/asteroid_sdk/supervision/supervisors.py
@@ -57,7 +57,7 @@ class ChatSupervisor(Protocol):
 
     def __call__(
         self,
-        message: ChatCompletionMessage,
+        message: str,
         supervision_context: Optional[SupervisionContext],
         ignored_attributes: list[str] = [],
         supervision_request_id: Optional[UUID] = None,
@@ -333,7 +333,7 @@ def chat_supervisor_decorator(**config_kwargs) -> Callable:
     def decorator(func: Callable) -> ChatSupervisor:
         @wraps(func)
         def wrapper(
-            message: dict,
+            message: str,
             supervision_context: Optional[SupervisionContext] = None,
             ignored_attributes: list[str] = [],
             supervision_request_id: Optional[UUID] = None,

--- a/src/asteroid_sdk/wrappers/openai.py
+++ b/src/asteroid_sdk/wrappers/openai.py
@@ -32,7 +32,7 @@ class CompletionsWrapper:
         self.run_id = run_id
         self.execution_mode = execution_mode
 
-    def create(self, *args, chat_supervisors: Optional[List[Callable]] = None, **kwargs) -> Any:
+    def create(self, *args, chat_supervisors: Optional[List[List[Callable]]] = None, **kwargs) -> Any:
         # If parallel tool calls not set to false (or doesn't exist, defaulting to true), then raise an error.
         # Parallel tool calls do not work at the moment due to conflicts when trying to 'resample'
         if kwargs.get("tools", None) and kwargs.get("parallel_tool_calls", True) :
@@ -49,7 +49,7 @@ class CompletionsWrapper:
         else:
             raise ValueError(f"Invalid execution mode: {self.execution_mode}")
 
-    def create_sync(self, *args, chat_supervisors: Optional[List[Callable]] = None, **kwargs) -> Any:
+    def create_sync(self, *args, chat_supervisors: Optional[List[List[Callable]]] = None, **kwargs) -> Any:
         # Log the entire request payload
         try:
             self.chat_supervision_manager.log_request(kwargs, self.run_id)
@@ -81,7 +81,7 @@ class CompletionsWrapper:
             except AsteroidLoggingError:
                 raise e
 
-    async def create_async(self, *args, chat_supervisors: Optional[List[Callable]] = None, **kwargs) -> Any:
+    async def create_async(self, *args, chat_supervisors: Optional[List[List[Callable]]] = None, **kwargs) -> Any:
         # Log the entire request payload asynchronously
         try:
             await asyncio.to_thread(self.chat_supervision_manager.log_request, kwargs, self.run_id)


### PR DESCRIPTION
The goal is to enable supervision of chat messages. #9 

We create a fake `chat_tool` tool call and reuse the backend logic. There will be some fixed needed on the frontend side to show this in an intuitive manner. This is how it looks like now.

**Basic example, 1 supervisor rejecting, no resampling:**

![image](https://github.com/user-attachments/assets/33874b6e-24d9-472b-935a-647379d0cfd0)
I think all good

**More complex example, 2 supervisors, with resampling:**
@joehewett you can run this example in `examples/chat_supervisors.py`
![image](https://github.com/user-attachments/assets/7bafa2ef-51c5-4e6b-b174-5e6a330f6eb7)


@joehewett we can discuss this together (+ I can walk you through the changes)