### PR TITLE
[SDK-5] feat: Asynchronous Monitoring Mode

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -29,15 +29,15 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Run commit message check
+      run: |
+        ./scripts/check_commit_message.sh
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel
         pip install .
-
-    - name: Run commit message check
-      run: |
-        ./scripts/check_commit_message.sh
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Async monitoring mode now using Threads instead of asyncio

This is because asyncio needs everything in the chain to be async, and we don't want to/haven't enforced that